### PR TITLE
Add pathPrefix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         }
     ],
     "require": {
-        "league/flysystem": "^1.0"
+        "league/flysystem": "^1.0",
+        "ext-pdo": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8"

--- a/src/PDOAdapter.php
+++ b/src/PDOAdapter.php
@@ -25,13 +25,13 @@ class PDOAdapter extends AbstractAdapter
      */
     protected $table;
 
-	/**
-	 * PDOAdapter constructor.
-	 *
-	 * @param PDO $pdo
-	 * @param string $tableName
-	 * @param string|null $pathPrefix
-	 */
+    /**
+     * PDOAdapter constructor.
+     *
+     * @param PDO $pdo
+     * @param string $tableName
+     * @param string|null $pathPrefix
+     */
     public function __construct(PDO $pdo, $tableName, $pathPrefix = null)
     {
         $this->pdo = $pdo;
@@ -88,7 +88,7 @@ class PDOAdapter extends AbstractAdapter
         $mimetype = Util::guessMimeType($path, $contents);
         $timestamp = $config->get('timestamp', time());
 
-		$pathWithPrefix = $this->applyPathPrefix($path);
+        $pathWithPrefix = $this->applyPathPrefix($path);
 
         $statement->bindParam(':size', $size, PDO::PARAM_INT);
         $statement->bindParam(':mimetype', $mimetype, PDO::PARAM_STR);
@@ -112,7 +112,7 @@ class PDOAdapter extends AbstractAdapter
      */
     public function rename($path, $newpath)
     {
-		$pathWithPrefix = $this->applyPathPrefix($path);
+        $pathWithPrefix = $this->applyPathPrefix($path);
         $statement = $this->pdo->prepare("SELECT type FROM {$this->table} WHERE path=:path");
         $statement->bindParam(':path', $pathWithPrefix, PDO::PARAM_STR);
 
@@ -140,8 +140,8 @@ class PDOAdapter extends AbstractAdapter
 
         $statement = $this->pdo->prepare("UPDATE {$this->table} SET path=:newpath WHERE path=:path");
 
-		$pathWithPrefix = $this->applyPathPrefix($path);
-		$newPathWithPrefix = $this->applyPathPrefix($newpath);
+        $pathWithPrefix = $this->applyPathPrefix($path);
+        $newPathWithPrefix = $this->applyPathPrefix($newpath);
         $statement->bindParam(':path', $pathWithPrefix, PDO::PARAM_STR);
         $statement->bindParam(':newpath', $newPathWithPrefix, PDO::PARAM_STR);
 
@@ -154,7 +154,7 @@ class PDOAdapter extends AbstractAdapter
     public function copy($path, $newpath)
     {
         $statement = $this->pdo->prepare("SELECT * FROM {$this->table} WHERE path=:path");
-		$pathWithPrefix = $this->applyPathPrefix($path);
+        $pathWithPrefix = $this->applyPathPrefix($path);
         $statement->bindParam(':path', $pathWithPrefix, PDO::PARAM_STR);
 
         if ($statement->execute()) {
@@ -162,7 +162,7 @@ class PDOAdapter extends AbstractAdapter
 
             if (!empty($result)) {
                 $statement = $this->pdo->prepare("INSERT INTO {$this->table} (path, contents, size, type, mimetype, timestamp) VALUES(:path, :contents, :size, :type, :mimetype, :timestamp)");
-				$newPathWithPrefix = $this->applyPathPrefix($newpath);
+                $newPathWithPrefix = $this->applyPathPrefix($newpath);
                 $statement->bindParam(':path', $newPathWithPrefix, PDO::PARAM_STR);
                 $statement->bindParam(':contents', $result['contents'], PDO::PARAM_LOB);
                 $statement->bindParam(':size', $result['size'], PDO::PARAM_INT);
@@ -183,7 +183,7 @@ class PDOAdapter extends AbstractAdapter
     public function delete($path)
     {
         $statement = $this->pdo->prepare("DELETE FROM {$this->table} WHERE path=:path");
-		$pathWithPrefix = $this->applyPathPrefix($path);
+        $pathWithPrefix = $this->applyPathPrefix($path);
         $statement->bindParam(':path', $pathWithPrefix, PDO::PARAM_STR);
 
         return $statement->execute();
@@ -208,7 +208,7 @@ class PDOAdapter extends AbstractAdapter
         }
 
         $statement = $this->pdo->prepare("DELETE FROM {$this->table} WHERE path=:path AND type='dir'");
-		$dirnameWithPrefix = $this->applyPathPrefix($dirname);
+        $dirnameWithPrefix = $this->applyPathPrefix($dirname);
         $statement->bindParam(':path', $dirnameWithPrefix, PDO::PARAM_STR);
 
         return $statement->execute();
@@ -243,7 +243,7 @@ class PDOAdapter extends AbstractAdapter
         $statement->bindParam(':path', $pathWithPrefix, PDO::PARAM_STR);
 
         if ($statement->execute()) {
-            return (bool) $statement->fetch(PDO::FETCH_ASSOC);
+            return (bool)$statement->fetch(PDO::FETCH_ASSOC);
         }
 
         return false;
@@ -256,7 +256,7 @@ class PDOAdapter extends AbstractAdapter
     {
         $statement = $this->pdo->prepare("SELECT contents FROM {$this->table} WHERE path=:path");
 
-		$pathWithPrefix = $this->applyPathPrefix($path);
+        $pathWithPrefix = $this->applyPathPrefix($path);
         $statement->bindParam(':path', $pathWithPrefix, PDO::PARAM_STR);
 
         if ($statement->execute()) {
@@ -293,7 +293,7 @@ class PDOAdapter extends AbstractAdapter
     {
         $query = "SELECT path, size, type, mimetype, timestamp FROM {$this->table}";
 
-        $useWhere = (bool) strlen($this->applyPathPrefix($directory));
+        $useWhere = (bool)strlen($this->applyPathPrefix($directory));
 
         if ($useWhere) {
             $query .= " WHERE path LIKE :path_prefix OR path=:path";
@@ -314,9 +314,9 @@ class PDOAdapter extends AbstractAdapter
 
         $result = $statement->fetchAll(PDO::FETCH_ASSOC);
 
-        $result = array_map(function($v) {
-            $v['timestamp'] = (int) $v['timestamp'];
-            $v['size'] = (int) $v['size'];
+        $result = array_map(function ($v) {
+            $v['timestamp'] = (int)$v['timestamp'];
+            $v['size'] = (int)$v['size'];
             $v['path'] = $this->removePathPrefix($v['path']);
             $v['dirname'] = Util::dirname($v['path']);
 

--- a/tests/PDOAdapterTest.php
+++ b/tests/PDOAdapterTest.php
@@ -51,7 +51,7 @@ class PDOAdapterTest extends \PHPUnit_Framework_TestCase
         $this->pdo->exec($createTableSql);
 
         $this->adapter = new PDOAdapter($this->pdo, $this->table, $this->pathPrefix);
-        $this->filesystem= new Filesystem($this->adapter);
+        $this->filesystem = new Filesystem($this->adapter);
     }
 
     protected function getTableContents($stripTimestampFromReturnedRows = true)
@@ -60,13 +60,13 @@ class PDOAdapterTest extends \PHPUnit_Framework_TestCase
         $statement->execute();
         $result = $statement->fetchAll(PDO::FETCH_ASSOC);
 
-        return array_map(function($v) use($stripTimestampFromReturnedRows) {
+        return array_map(function ($v) use ($stripTimestampFromReturnedRows) {
             unset($v['id']);
-            if($stripTimestampFromReturnedRows) {
+            if ($stripTimestampFromReturnedRows) {
                 unset($v['timestamp']);
             }
             $v['path'] = $this->adapter->removePathPrefix($v['path']);
-            $v['size'] = (int) $v['size'];
+            $v['size'] = (int)$v['size'];
 
             return $v;
         }, $result);
@@ -79,7 +79,7 @@ class PDOAdapterTest extends \PHPUnit_Framework_TestCase
 
     protected function filterContents($contents)
     {
-        return array_map(function($v) {
+        return array_map(function ($v) {
             unset($v['timestamp']);
 
             return $v;
@@ -117,7 +117,13 @@ class PDOAdapterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTableContains([
             ['path' => 'foo', 'contents' => null, 'type' => 'dir', 'size' => 0, 'mimetype' => null],
-            ['path' => $path1, 'contents' => $contents1, 'type' => 'file', 'size' => strlen($contents1), 'mimetype' => 'text/plain']
+            [
+                'path' => $path1,
+                'contents' => $contents1,
+                'type' => 'file',
+                'size' => strlen($contents1),
+                'mimetype' => 'text/plain'
+            ]
         ]);
 
         $path2 = 'foo/bar/baz.txt';
@@ -126,8 +132,20 @@ class PDOAdapterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTableContains([
             ['path' => 'foo', 'contents' => null, 'type' => 'dir', 'size' => 0, 'mimetype' => null],
-            ['path' => $path1, 'contents' => $contents1, 'type' => 'file', 'size' => strlen($contents1), 'mimetype' => 'text/plain'],
-            ['path' => $path2, 'contents' => $contents2, 'type' => 'file', 'size' => strlen($contents2), 'mimetype' => 'text/plain']
+            [
+                'path' => $path1,
+                'contents' => $contents1,
+                'type' => 'file',
+                'size' => strlen($contents1),
+                'mimetype' => 'text/plain'
+            ],
+            [
+                'path' => $path2,
+                'contents' => $contents2,
+                'type' => 'file',
+                'size' => strlen($contents2),
+                'mimetype' => 'text/plain'
+            ]
         ]);
     }
 
@@ -143,9 +161,23 @@ class PDOAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->filesystem->write($path1, $contents1, $config));
 
         $this->assertTableContains([
-                ['path' => 'foo', 'contents' => null, 'type' => 'dir', 'size' => 0, 'mimetype' => null, 'timestamp' => $timestamp],
-                ['path' => $path1, 'contents' => $contents1, 'type' => 'file', 'size' => strlen($contents1), 'mimetype' => 'text/plain', 'timestamp' => $timestamp]
+            [
+                'path' => 'foo',
+                'contents' => null,
+                'type' => 'dir',
+                'size' => 0,
+                'mimetype' => null,
+                'timestamp' => $timestamp
             ],
+            [
+                'path' => $path1,
+                'contents' => $contents1,
+                'type' => 'file',
+                'size' => strlen($contents1),
+                'mimetype' => 'text/plain',
+                'timestamp' => $timestamp
+            ]
+        ],
             false
         );
     }

--- a/tests/PDOAdapterTest.php
+++ b/tests/PDOAdapterTest.php
@@ -50,10 +50,7 @@ class PDOAdapterTest extends \PHPUnit_Framework_TestCase
 
         $this->pdo->exec($createTableSql);
 
-        $this->adapter = new PDOAdapter($this->pdo, [
-            'tableName' => $this->table,
-            'prefix' => $this->pathPrefix
-        ]);
+        $this->adapter = new PDOAdapter($this->pdo, $this->table, $this->pathPrefix);
         $this->filesystem= new Filesystem($this->adapter);
     }
 

--- a/tests/PDOAdapterTest.php
+++ b/tests/PDOAdapterTest.php
@@ -27,6 +27,10 @@ class PDOAdapterTest extends \PHPUnit_Framework_TestCase
      * @var string
      */
     protected $table = 'files';
+    /**
+     * @var string
+     */
+    protected $pathPrefix = '/test/';
 
     public function setUp()
     {
@@ -46,7 +50,10 @@ class PDOAdapterTest extends \PHPUnit_Framework_TestCase
 
         $this->pdo->exec($createTableSql);
 
-        $this->adapter = new PDOAdapter($this->pdo, $this->table);
+        $this->adapter = new PDOAdapter($this->pdo, [
+            'tableName' => $this->table,
+            'prefix' => $this->pathPrefix
+        ]);
         $this->filesystem= new Filesystem($this->adapter);
     }
 
@@ -61,6 +68,7 @@ class PDOAdapterTest extends \PHPUnit_Framework_TestCase
             if($stripTimestampFromReturnedRows) {
                 unset($v['timestamp']);
             }
+            $v['path'] = $this->adapter->removePathPrefix($v['path']);
             $v['size'] = (int) $v['size'];
 
             return $v;


### PR DESCRIPTION
It is convenient to use when two Replicate Adapters are set on the same folder, but one of the adapters is set on the internal folder, i.e. the first dapter is built on '/test/' the second on '/test/test2'.
The same table is used.